### PR TITLE
Accept `unauthorized` spelling for failure reason

### DIFF
--- a/lib/auto_api/states/failure_message_state.ex
+++ b/lib/auto_api/states/failure_message_state.ex
@@ -111,11 +111,11 @@ defmodule AutoApi.FailureMessageState do
 
   defp unify_unauthorized_from_bin(value), do: value
 
-  #  defp unify_unauthorized_to_bin(
-  #         %{failure_reason: %{data: :unauthorized} = failure_reason} = state
-  #       ) do
-  #    %{state | failure_reason: %{failure_reason | data: :unauthorised}}
-  #  end
+  defp unify_unauthorized_to_bin(
+         %{failure_reason: %{data: :unauthorized} = failure_reason} = state
+       ) do
+    %{state | failure_reason: %{failure_reason | data: :unauthorised}}
+  end
 
   defp unify_unauthorized_to_bin(value), do: value
 end

--- a/test/auto_api/states/failure_message_state_test.exs
+++ b/test/auto_api/states/failure_message_state_test.exs
@@ -25,7 +25,7 @@ defmodule AutoApi.FailureMessageStateTest do
   use PropCheck
 
   import AutoApi.PropCheckFixtures
-  alias AutoApi.{FailureMessageState, State}
+  alias AutoApi.{FailureMessageState, State, Property}
 
   doctest AutoApi.FailureMessageState
 
@@ -55,7 +55,6 @@ defmodule AutoApi.FailureMessageStateTest do
       %FailureMessageState{}
       |> State.put(:failed_message_id, data: 0x35)
       |> State.put(:failed_message_type, data: 0x00)
-      #      |> State.put(:failure_reason, data: :unauthorized)
       |> State.put(:failure_reason, data: :unauthorised)
       |> State.put(
         :failure_description,
@@ -68,5 +67,25 @@ defmodule AutoApi.FailureMessageStateTest do
       |> FailureMessageState.from_bin()
 
     assert new_state == state
+  end
+
+  test "to_bin accepts reason with unauthorized spelling" do
+    state =
+      %FailureMessageState{}
+      |> State.put(:failed_message_id, data: 0x35)
+      |> State.put(:failed_message_type, data: 0x00)
+      |> State.put(:failure_reason, data: :unauthorized)
+      |> State.put(
+        :failure_description,
+        data: "Access to this capability was not granted"
+      )
+
+    new_state =
+      state
+      |> FailureMessageState.to_bin()
+      |> FailureMessageState.from_bin()
+
+    expected_state = %{state | failure_reason: %Property{data: :unauthorised}}
+    assert new_state == expected_state
   end
 end


### PR DESCRIPTION
This is not to make systems fail when converting the failure to bin when
the enum is spelled like this as it is a very common error.

Parsing back from binary is unaffected and it leaves the enum with the
specified spelling.