### PR TITLE
Handle invalid binary conversion 

### DIFF
--- a/lib/auto_api/property.ex
+++ b/lib/auto_api/property.ex
@@ -201,6 +201,13 @@ defmodule AutoApi.Property do
     type_id = AutoApi.UnitType.id(type)
     unit_id = AutoApi.UnitType.unit_id(type, unit)
 
+    unless unit_id,
+      do:
+        Logger.warn([
+          "type `#{type}` doesn't support unit `#{unit}`",
+          " stacktrace: #{inspect Process.info(self(), :current_stacktrace)}"
+        ])
+
     <<type_id, unit_id, value::float-size(64)>>
   end
 

--- a/lib/auto_api/unit_type_meta.ex
+++ b/lib/auto_api/unit_type_meta.ex
@@ -105,8 +105,10 @@ defmodule AutoApi.UnitType.Meta do
             0x02
             iex> AutoApi.UnitType.unit_id("power", :megawatts)
             0x03
+            iex> AutoApi.UnitType.unit_id("power", :foobar)
+            nil
         """
-        @spec unit_id(String.t() | atom(), atom()) :: id()
+        @spec unit_id(String.t() | atom(), atom()) :: id() | nil
         def unit_id(type_name, unit_name)
 
         @doc """

--- a/test/auto_api/property_test.exs
+++ b/test/auto_api/property_test.exs
@@ -21,6 +21,7 @@ defmodule AutoApi.PropertyTest do
   use PropCheck
 
   import AutoApi.PropCheckFixtures
+  import ExUnit.CaptureLog
 
   alias AutoApi.Property
 
@@ -755,6 +756,27 @@ defmodule AutoApi.PropertyTest do
         assert prop_comp.failure == component.failure
         assert prop_comp.availability == component.availability
       end
+    end
+  end
+
+  describe "to_binary/2" do
+    test "emmits warn log and raise ArgumentError  when an invalid unit type to binary" do
+      spec = %{
+        "id" => 24,
+        "name" => "charging_rate",
+        "type" => "unit.power",
+        size: 10
+      }
+
+      prop_comp = %Property{data: %{value: 10.009, unit: :celsius}}
+
+      fun = fn ->
+        assert_raise ArgumentError, fn ->
+          Property.to_bin(prop_comp, spec)
+        end
+      end
+
+      assert capture_log(fun) =~ "type `power` doesn't support unit `celsius`"
     end
   end
 

--- a/test/auto_api/state_test.exs
+++ b/test/auto_api/state_test.exs
@@ -201,6 +201,21 @@ defmodule AutoApi.StateTest do
       assert state == new_state
     end
 
+    test "converts invalid input to failure property" do
+      state = %RooftopControlState{
+        sunroof_tilt_state: %Property{data: :boo}
+      }
+
+      new_state =
+        state
+        |> RooftopControlState.to_bin()
+        |> RooftopControlState.from_bin()
+
+      assert new_state.sunroof_tilt_state == %AutoApi.Property{
+               failure: %{description: "not able to serialize the value", reason: :format_error}
+             }
+    end
+
     test "failure on list property" do
       pressures = %Property{failure: %{reason: :unknown, description: "Unknown"}}
       state = %DiagnosticsState{tire_pressures: [pressures]}


### PR DESCRIPTION
With this PR, `Property.to_binary/2` handles unexpected parsing errors and returns a property with failure message:
```elixir
%AutoAPI.Property{
   failure: %{reason: :format_error, description: "not able to serialize the value"}
 }
```