### PR TITLE
Upgrade ubuntu on GH Actions to Ubuntu 20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
            otp: '22.3'
          - elixir: '1.11.2'
            otp: '23.1'
-   runs-on: ubuntu-22.04
+   runs-on: ubuntu-20.04
    steps:
      - uses: actions/checkout@v3
      - uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
            otp: '22.3'
          - elixir: '1.11.2'
            otp: '23.1'
-   runs-on: ubuntu-18.04
+   runs-on: ubuntu-22.04
    steps:
      - uses: actions/checkout@v3
      - uses: actions/cache@v3


### PR DESCRIPTION
`erlef/setup-beam` highest ubuntu version that supports OTP 22 at the moment is 20.04.
https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp

We may be able to upgrade ubuntu as soon as we drop OTP<24.2 support.